### PR TITLE
Fix camera2global returning incorrect position

### DIFF
--- a/GCC2D.gd
+++ b/GCC2D.gd
@@ -52,7 +52,7 @@ func _unhandled_input(e):
 
 # Given a a position on the camera returns to the corresponding global position
 func camera2global(position):
-	var camera_center = global_position + position
+	var camera_center = global_position
 	var from_camera_center_pos = position - get_camera_center_offset()
 	return camera_center + (from_camera_center_pos*zoom).rotated(rotation)
 


### PR DESCRIPTION
I was using `camera.camera2global()` in order to convert a touch position from screen coord to global coord. I noticed this function was not returning right position. This PR fixes it.

To reproduce the bug, I put together a branch [bug-demo](https://github.com/OmarShehata/GestureControlledCamera2D/tree/bug-demo). This adds a node that follows the mouse with the following script:

```gdscript
extends Node2D

var camera

func _ready():
	camera = get_tree().get_root().get_node("/root/Node2D/GCC2D")
	print(camera)

func _input(event):
	if event is InputEventMouseMotion:
		var screenPosition = event.position
		var globalPosition = camera.camera2global(screenPosition)
		transform.origin.x = globalPosition.x 
		transform.origin.y = globalPosition.y
```

Before this fix, you'll notice the pointer strays away from the mouse position as you move it towards the right side of the screen, and strays even further as you zoom out/in. With this fix, it's always at the correct position.